### PR TITLE
fix: install dependencies before using poe in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
         cache-dependency-glob: pyproject.toml
 
     - name: Install dependencies
+      run: uv sync --all-extras --dev
+
+    - name: Install dependencies (poe task)
       run: poe setup
 
     - name: Check if the documentation builds correctly
@@ -141,6 +144,11 @@ jobs:
         cache-suffix: ${{ matrix.resolution }}
 
     - name: Install dependencies
+      env:
+        UV_RESOLUTION: ${{ matrix.resolution }}
+      run: uv sync --all-extras --dev
+
+    - name: Install dependencies (poe task)
       env:
         UV_RESOLUTION: ${{ matrix.resolution }}
       run: poe setup


### PR DESCRIPTION
### For reviewers

- [ ] I did not use AI
- [ ] I used AI and thoroughly reviewed every code/docs change

### Description of the change
Split dependency installation in CI workflow into two steps: first using `uv sync --all-extras --dev` directly, then running the existing `poe setup` task. This change applies to both the documentation and test jobs.

### Relevant resources

-
-
-