### PR TITLE
fix: enable uv cache in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,11 @@ jobs:
         fetch-depth: 0
         fetch-tags: true
 
-    - name: Setup Python
-      uses: actions/setup-python@v6
+    - name: Setup uv and Python
+      uses: astral-sh/setup-uv@v7.1.5
       with:
         python-version: "3.13"
-
-    - name: Setup uv
-      uses: astral-sh/setup-uv@v5
+        enable-cache: true
 
     - name: Install dependencies
       run: uv sync --group maintain


### PR DESCRIPTION
The release workflow was failing because `uv build` command was not found during semantic-release. 

This PR adds `enable-cache: true` to the uv setup in the release workflow to ensure uv is properly initialized before semantic-release runs.

Fixes the CI failure where semantic-release couldn't build the package with exit code 127.
