### PR TITLE
chore: update template to 2.6.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier.
-_commit: 2.5.2
+_commit: 2.6.3
 _src_path: gh:ichoosetoaccept/copier-uv-bleeding
 author_email: ismar@gmail.com
 author_fullname: Ismar Iljazovic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: ci
 
-on:
+"on":
   push:
     branches:
     - main
@@ -34,15 +34,8 @@ jobs:
         - macos-latest
         - windows-latest
         python-version:
-        - "3.10"
+        - "3.13"
         - "3.14"
-        include:
-        - os: ubuntu-latest
-          python-version: "3.11"
-        - os: ubuntu-latest
-          python-version: "3.12"
-        - os: ubuntu-latest
-          python-version: "3.13"
 
     runs-on: ${{ matrix.os }}
 
@@ -61,28 +54,28 @@ jobs:
         cache-dependency-glob: pyproject.toml
 
     - name: Install dependencies
-      run: uv sync --all-extras --dev
-
-    - name: Install dependencies (poe task)
-      run: poe setup
+      run: uv run poe setup
 
     - name: Check if the documentation builds correctly
-      run: poe docs-build
+      run: |
+        mkdir -p htmlcov
+        echo '<html><body>No coverage report yet</body></html>' > htmlcov/index.html
+        uv run poe docs-build
 
     - name: Check the code quality
-      run: poe lint
+      run: uv run poe lint
 
     - name: Check if the code is correctly typed
-      run: poe typecheck
+      run: uv run poe typecheck
 
     - name: Check for security vulnerabilities
-      run: poe security
+      run: uv run poe security
 
     - name: Check for dead code
-      run: poe deadcode
+      run: uv run poe deadcode
 
     - name: Check for breaking changes in the API
-      run: poe lint
+      run: uv run poe lint
 
     - name: Store objects inventory for tests
       uses: actions/upload-artifact@v4
@@ -102,9 +95,6 @@ jobs:
         - macos-latest
         - windows-latest
         python-version:
-        - "3.10"
-        - "3.11"
-        - "3.12"
         - "3.13"
         - "3.14"
         - "3.15"
@@ -125,6 +115,7 @@ jobs:
       with:
         fetch-depth: 0
         fetch-tags: true
+        lfs: true
 
     - name: Setup Python
       uses: actions/setup-python@v6
@@ -142,12 +133,7 @@ jobs:
     - name: Install dependencies
       env:
         UV_RESOLUTION: ${{ matrix.resolution }}
-      run: uv sync --all-extras --dev
-
-    - name: Install dependencies (poe task)
-      env:
-        UV_RESOLUTION: ${{ matrix.resolution }}
-      run: poe setup
+      run: uv run poe setup
 
     - name: Download objects inventory
       uses: actions/download-artifact@v4
@@ -156,4 +142,4 @@ jobs:
         path: site/
 
     - name: Run the test suite
-      run: poe test
+      run: uv run poe test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: release
 
-on:
+"on":
   push:
     branches:
       - main
@@ -30,22 +30,17 @@ jobs:
     - name: Install dependencies
       run: uv sync --group maintain
 
-    - name: Python Semantic Release
-      id: release
-      uses: python-semantic-release/python-semantic-release@v9
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Semantic Release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: uv run semantic-release version --changelog --push --tag --vcs-release
 
     # Uncomment to publish to PyPI:
     # - name: Publish to PyPI
-    #   if: ${{ steps.release.outputs.released == 'true' && secrets.PYPI_TOKEN != '' }}
-    #   uses: pypa/gh-action-pypi-publish@release/v1
-    #   with:
-    #     password: ${{ secrets.PYPI_TOKEN }}
-
-    - name: Publish to GitHub Releases
-      if: steps.release.outputs.released == 'true'
-      uses: python-semantic-release/publish-action@v9
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ steps.release.outputs.tag }}
+    #   if: secrets.PYPI_TOKEN != ''
+    #   env:
+    #     PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+    #   run: |
+    #     if [ -n "$PYPI_TOKEN" ]; then
+    #       uv publish --token $PYPI_TOKEN
+    #     fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,11 @@ repos:
     hooks:
       - id: uv-lock
 
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.9  # prek autoupdate will fill this
+    hooks:
+      - id: actionlint
+
   - repo: local
     hooks:
       - id: ty


### PR DESCRIPTION
Update to copier template version 2.6.3 + project-specific LFS fix.

## Template Changes (2.6.3)
- **Release workflow fix**: Now runs `semantic-release` directly via `uv run` instead of using the GitHub Action, which fixes the 'uv build command not found' error (exit code 127)
- **CI Python version fix**: Updated CI matrix to only test Python 3.13+ (matching `requires-python = '>=3.13'`)
- **CI poe command fix**: Changed all `poe` commands to `uv run poe` to ensure poe is available via uv's virtual environment
- **Docs build fix**: Creates placeholder `htmlcov` directory before docs build to avoid strict mode warning
- Uses `GH_TOKEN` environment variable instead of `github_token` input
- Added actionlint pre-commit hook for GitHub Actions workflow linting

## Project-specific fix
- **LFS support**: Added `lfs: true` to tests checkout step to fetch `swagger.json` which is stored in Git LFS