### PR TITLE
feat: add kubernetes port-forward wrapper and trusted headers auth

### DIFF
--- a/contrib/k8s/README.md
+++ b/contrib/k8s/README.md
@@ -1,0 +1,89 @@
+# Kubernetes Port-Forward Wrapper
+
+This wrapper script enables `unblu-mcp` to work with Unblu deployments that are only accessible via Kubernetes port-forwarding.
+
+## Use Case
+
+Enterprise deployments often run Unblu behind Kubernetes services that aren't directly accessible from developer machines. This wrapper:
+
+1. Automatically detects the target environment from your kubectl context
+2. Starts a port-forward to the Unblu haproxy service
+3. Configures trusted headers authentication
+4. Launches the MCP server
+
+## Installation
+
+```bash
+# Make the script executable
+chmod +x contrib/k8s/unblu-mcp-k8s
+
+# Optionally, symlink to your PATH
+ln -s $(pwd)/contrib/k8s/unblu-mcp-k8s ~/.local/bin/unblu-mcp-k8s
+```
+
+## Usage
+
+```bash
+# Auto-detect environment from kubectl context
+./contrib/k8s/unblu-mcp-k8s
+
+# Specify environment explicitly
+./contrib/k8s/unblu-mcp-k8s t1
+./contrib/k8s/unblu-mcp-k8s t2
+./contrib/k8s/unblu-mcp-k8s p1
+./contrib/k8s/unblu-mcp-k8s e1
+```
+
+## MCP Client Configuration
+
+### Windsurf / Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "unblu": {
+      "command": "/path/to/unblu-mcp/contrib/k8s/unblu-mcp-k8s",
+      "args": ["t1"]
+    }
+  }
+}
+```
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `UNBLU_MCP_PATH` | Path to unblu-mcp repo if not installed globally | - |
+| `UNBLU_K8S_NAMESPACE` | Override namespace pattern | `appl-kop-{env}` |
+| `UNBLU_K8S_SERVICE` | Override service name | `haproxy` |
+| `UNBLU_K8S_PORT` | Override service port | `8080` |
+
+## Port Mapping
+
+Each environment uses a different local port to allow multiple environments simultaneously:
+
+| Environment | Local Port |
+|-------------|------------|
+| t1 | 8084 |
+| t2 | 8085 |
+| p1 | 8086 |
+| e1 | 8087 |
+
+## Prerequisites
+
+- `kubectl` configured with appropriate contexts
+- `unblu-mcp` installed (`uv tool install unblu-mcp`) or available via `UNBLU_MCP_PATH`
+- Network access to the Kubernetes cluster
+
+## Customization
+
+To adapt this for your environment:
+
+1. Modify the `ENV_PORTS` array for your port preferences
+2. Adjust `detect_environment()` to match your kubectl context naming
+3. Change the namespace pattern in `UNBLU_K8S_NAMESPACE` if needed
+4. Update the service name if your Unblu deployment uses a different ingress
+
+## Related
+
+- [GitHub Issue #17](https://github.com/ichoosetoaccept/unblu-mcp/issues/17) - Long-term plan for connection provider plugin system

--- a/contrib/k8s/unblu-mcp-k8s
+++ b/contrib/k8s/unblu-mcp-k8s
@@ -1,0 +1,191 @@
+#!/bin/bash
+# Kubernetes Port-Forward Wrapper for unblu-mcp
+# Handles kubectl port-forwarding for enterprise deployments where Unblu API
+# is only accessible via Kubernetes services.
+#
+# Usage: unblu-mcp-k8s [environment]
+#   environment: t1, t2, p1, e1 (default: auto-detect from kubectl context)
+#
+# This wrapper:
+# 1. Detects or sets the Kubernetes environment
+# 2. Starts kubectl port-forward to haproxy service
+# 3. Configures trusted headers authentication
+# 4. Launches the unblu-mcp server
+#
+# Environment Variables:
+#   UNBLU_MCP_PATH      - Path to unblu-mcp repo (if not installed globally)
+#   UNBLU_K8S_NAMESPACE - Override namespace pattern (default: appl-kop-{env})
+#   UNBLU_K8S_SERVICE   - Override service name (default: haproxy)
+#   UNBLU_K8S_PORT      - Override service port (default: 8080)
+#
+# Prerequisites:
+# - kubectl configured with appropriate contexts
+# - unblu-mcp installed (uv tool install unblu-mcp or from source)
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Port mapping per environment (must not conflict with each other)
+# Using function instead of associative array for bash 3.x compatibility
+get_port() {
+  case "$1" in
+    t1) echo 8084 ;;
+    t2) echo 8085 ;;
+    p1) echo 8086 ;;
+    e1) echo 8087 ;;
+    *) echo "" ;;
+  esac
+}
+
+is_valid_env() {
+  case "$1" in
+    t1|t2|p1|e1) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Detect environment from kubectl context
+detect_environment() {
+  local context
+  context=$(kubectl config current-context 2>/dev/null || echo "")
+  
+  # shellcheck disable=SC2254
+  case "$context" in
+    *-t1-*|*-t1) echo "t1" ;;
+    *-t2-*|*-t2) echo "t2" ;;
+    *-p1-*|*-p1) echo "p1" ;;
+    *-e1-*|*-e1) echo "e1" ;;
+    *) echo "" ;;
+  esac
+}
+
+# Check if port-forward is already running
+is_port_forward_running() {
+  local port=$1
+  lsof -Pi ":${port}" -sTCP:LISTEN -t >/dev/null 2>&1
+}
+
+# Start port-forward
+start_port_forward() {
+  local env=$1
+  local port
+  port=$(get_port "$env")
+  local namespace="${UNBLU_K8S_NAMESPACE:-appl-kop-${env}}"
+  local service="${UNBLU_K8S_SERVICE:-haproxy}"
+  local svc_port="${UNBLU_K8S_PORT:-8080}"
+  
+  if is_port_forward_running "$port"; then
+    echo "✅ Port-forward already running on port ${port}" >&2
+    return 0
+  fi
+  
+  echo "🔌 Starting port-forward to ${namespace}/${service} on port ${port}..." >&2
+  kubectl port-forward -n "${namespace}" "svc/${service}" "${port}:${svc_port}" >/dev/null 2>&1 &
+  PORTFORWARD_PID=$!
+  
+  # Wait for port to become available
+  local attempts=0
+  while ! is_port_forward_running "$port"; do
+    sleep 0.5
+    attempts=$((attempts + 1))
+    if [ $attempts -ge 10 ]; then
+      echo "❌ Failed to start port-forward after 5 seconds" >&2
+      kill "$PORTFORWARD_PID" 2>/dev/null || true
+      exit 1
+    fi
+  done
+  
+  echo "✅ Port-forward ready (PID: ${PORTFORWARD_PID})" >&2
+}
+
+# Cleanup on exit
+cleanup() {
+  if [ -n "${PORTFORWARD_PID:-}" ] && kill -0 "$PORTFORWARD_PID" 2>/dev/null; then
+    echo "🧹 Stopping port-forward..." >&2
+    kill "$PORTFORWARD_PID" 2>/dev/null || true
+    wait "$PORTFORWARD_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# Find unblu-mcp command
+find_unblu_mcp() {
+  # Check if unblu-mcp is in PATH
+  if command -v unblu-mcp >/dev/null 2>&1; then
+    echo "unblu-mcp"
+    return 0
+  fi
+  
+  # Check UNBLU_MCP_PATH env var
+  if [ -n "${UNBLU_MCP_PATH:-}" ] && [ -f "${UNBLU_MCP_PATH}/pyproject.toml" ]; then
+    echo "uv run --directory ${UNBLU_MCP_PATH} unblu-mcp"
+    return 0
+  fi
+  
+  # Check if we're in the unblu-mcp repo
+  if [ -f "${SCRIPT_DIR}/../../pyproject.toml" ]; then
+    echo "uv run --directory ${SCRIPT_DIR}/../.. unblu-mcp"
+    return 0
+  fi
+  
+  echo ""
+}
+
+# Main
+main() {
+  local env="${1:-}"
+  shift || true  # Remove env from args if present
+  
+  # Auto-detect environment if not provided
+  if [ -z "$env" ]; then
+    env=$(detect_environment)
+    if [ -z "$env" ]; then
+      echo "❌ Could not detect environment from kubectl context." >&2
+      echo "   Please specify: $0 <t1|t2|p1|e1>" >&2
+      echo "   Or switch kubectl context to one containing the environment name" >&2
+      exit 1
+    fi
+    echo "🔍 Auto-detected environment: ${env}" >&2
+  fi
+  
+  # Validate environment
+  if ! is_valid_env "$env"; then
+    echo "❌ Invalid environment: ${env}" >&2
+    echo "   Valid options: t1, t2, p1, e1" >&2
+    exit 1
+  fi
+  
+  local port
+  port=$(get_port "$env")
+  
+  # Find unblu-mcp
+  local unblu_mcp_cmd
+  unblu_mcp_cmd=$(find_unblu_mcp)
+  if [ -z "$unblu_mcp_cmd" ]; then
+    echo "❌ unblu-mcp not found." >&2
+    echo "   Install with: uv tool install unblu-mcp" >&2
+    echo "   Or set UNBLU_MCP_PATH to the repo directory" >&2
+    exit 1
+  fi
+  
+  # Start port-forward
+  start_port_forward "$env"
+  
+  # Configure environment for unblu-mcp
+  export UNBLU_BASE_URL="http://localhost:${port}/kop/rest/v4"
+  
+  # Configure trusted headers authentication
+  export UNBLU_TRUSTED_HEADERS="x-unblu-trusted-user-id:superadmin,x-unblu-trusted-user-role:SUPER_ADMIN"
+  
+  echo "🚀 Starting unblu-mcp for ${env} environment..." >&2
+  echo "   Base URL: ${UNBLU_BASE_URL}" >&2
+  echo "   Auth: Trusted headers" >&2
+  echo "" >&2
+  
+  # Run unblu-mcp with any additional args
+  # shellcheck disable=SC2086
+  exec $unblu_mcp_cmd "$@"
+}
+
+main "$@"


### PR DESCRIPTION
### For reviewers

- [x] I used AI and thoroughly reviewed every code/docs change

### Description of the change

Adds a **Kubernetes port-forward wrapper script** for enterprise deployments where the Unblu API is only accessible via kubectl port-forward.

#### New Components

- **`contrib/k8s/unblu-mcp-k8s`** - Shell wrapper script that:
  - Starts kubectl port-forward to the Unblu service
  - Sets up trusted headers authentication (`x-unblu-trusted-user-id`, `x-unblu-trusted-user-role`)
  - Launches the MCP server with the correct environment
  - Cleans up port-forward on exit

- **`contrib/k8s/README.md`** - Documentation for the wrapper script

#### Use Case

For environments where:
- Unblu API is only accessible within a Kubernetes cluster
- Authentication uses trusted headers instead of API keys
- Port-forwarding is required to reach the service

### Relevant resources

- Related to #17 (connection provider plugin system)