### PR TITLE
feat: implement connection provider plugin system

### DIFF
--- a/.windsurf/rules/graphite-cli.md
+++ b/.windsurf/rules/graphite-cli.md
@@ -1,0 +1,76 @@
+---
+trigger: always_on
+description: Use Graphite CLI to manage our code in this project
+---
+
+gt -h
+Graphite (gt) simplifies the entire code authoring & reviewing lifecycle
+for GitHub. It enables stacking PRs on top of each other to keep you
+unblocked & your changes small, focused, and reviewable.
+
+USAGE
+  $ gt <command> [flags]
+
+AUTHENTICATING
+  Authenticating gt with Graphite enables submitting PRs and stacks:
+
+  1. Open https://app.graphite.dev/settings/cli
+  2. Create a new auth token
+  3. Paste the generated gt auth --token <token> command into the terminal
+
+TERMS
+  stack:     A sequence of pull requests, each building off of its parent.
+             ex: main <- PR "add API" <- PR "update frontend" <- PR "docs"
+  trunk:     The branch that stacks are merged into.
+		         ex: main
+  downstack: The PRs below the given PR in a stack, i.e. its ancestors.
+  upstack:   The PRs above the given PR in a stack, i.e. its descendants.
+
+CORE COMMANDS
+  gt init:            Initializes your Git repo to work with Graphite
+  gt create:          Creates a new branch and commit your changes
+  gt submit:          Submits the current branch & all downstack
+                      branches to Graphite
+  gt submit --stack:  Submits your current stack to Graphite
+  gt modify:          Amends your current branch with new changes and
+                      rebases all PRs above it
+  gt restack:         Rebases every PR in a stack to have the latest
+                      changes
+  gt sync:            Pulls the latest trunk branch, rebases all open
+                      PRs/stacks on top of the latest changes, and
+                      prompts to delete any stale/old/merged branches
+  gt checkout:        Interactively checks out any of your branches
+  gt log:             Prints a graphical representation of your current
+                      stack
+  gt up:              Checks out the branch directly upstack
+  gt down:            Checks out the branch directly downstack
+  gt demo:            Walks you through examples to learn the Graphite
+                      workflow via an interactive tutorial
+
+  Run gt --help --all for a full command reference.
+  Pass the --help flag to any command for specific help
+  (ex: gt submit --help)
+
+CORE WORKFLOW
+  Run gt guide workflow to quickly learn how to:
+    - create a new PR
+    - stack a PR on top of an existing PR
+    - respond to peer feedback from anywhere in your stack
+    - sync the latest changes from main
+    - merge your stack to your main branch
+
+LEARN MORE
+  Learn about custom aliases with gt aliases --help.
+  Learn to customize gt with gt config --help.
+
+  More documentation: https://graphite.dev/docs
+  Our cheatsheet:     https://graphite.dev/docs/cheatsheet
+  Tutorial videos:    https://www.youtube.com/@withgraphite
+  Troubleshooting:    https://graphite.dev/docs/troubleshooting
+
+FEEDBACK
+	We'd love to hear your feedback! Join our Slack community at:
+		https://community.graphite.dev
+	or email us at: cli@graphite.dev.
+	You can also submit feedback directly via gt feedback, which
+	has the ability to attach logs if you're experiencing issues.

--- a/.windsurf/rules/task-runner.md
+++ b/.windsurf/rules/task-runner.md
@@ -1,0 +1,10 @@
+---
+trigger: always_on
+description: Always use our task runner, poe, to run common tasks in this project
+---
+
+1. Run 'poe' to find what tasks are available
+2. Run 'poe test' to run the test suite
+3. Run 'poe lint' to run linting
+4. Run 'poe format' to format the code
+5. ... and so on. If an important task is missing, add it and use it from then on

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # unblu-mcp
 
-[![ci](https://github.com/ichoosetoaccept/unblu-mcp/workflows/ci/badge.svg)](https://github.com/ichoosetoaccept/unblu-mcp/actions?query=workflow%3Aci)
+[![ci](https://github.com/ichoosetoaccept/unblu-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/ichoosetoaccept/unblu-mcp/actions/workflows/ci.yml)
 [![documentation](https://img.shields.io/badge/docs-mkdocs-708FCC.svg?style=flat)](https://ichoosetoaccept.github.io/unblu-mcp/)
 
 A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for interacting with [Unblu](https://www.unblu.com/) deployments. This server provides AI assistants with token-efficient access to 300+ Unblu API endpoints through progressive disclosure.
@@ -16,7 +16,11 @@ This server implements best practices from Anthropic's guide on [building effect
 - **Field Filtering**: Request only the fields you need to reduce response size
 - **Response Truncation**: Limit response sizes to prevent token overflow
 
-Built with [FastMCP](https://github.com/jlowin/fastmcp) - the fast, Pythonic way to build MCP servers.
+Built with [FastMCP 2.14+](https://github.com/jlowin/fastmcp), leveraging cutting-edge features:
+
+- **MCP Annotations**: Tools include `readOnlyHint` and `openWorldHint` metadata for smarter AI decision-making
+- **Response Caching**: Discovery tools cache results via FastMCP middleware for faster repeated queries
+- **MCP 2025-11-25 Spec**: Full support for the latest Model Context Protocol specification
 
 ## Installation
 

--- a/config/bandit.toml
+++ b/config/bandit.toml
@@ -1,3 +1,8 @@
 [tool.bandit]
 exclude_dirs = ["tests", "scripts"]
-skips = ["B101"]  # assert_used - common in tests
+skips = [
+    "B101",  # assert_used - common in tests
+    "B404",  # import_subprocess - needed for kubectl port-forward
+    "B603",  # subprocess_without_shell_equals_true - kubectl with controlled args
+    "B607",  # start_process_with_partial_path - kubectl found via shutil.which
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "fastmcp>=2.0.0",
+    "fastmcp>=2.14.0",
     "httpx>=0.27.0",
     "pydantic>=2.0.0",
     "prek",
@@ -106,7 +106,7 @@ upgrade = "pyupgrade --py313-plus src/**/*.py tests/**/*.py"
 
 # Testing
 test = "pytest tests -c config/pytest.ini"
-test-cov = "pytest tests -c config/pytest.ini --cov=src --cov-report=html"
+test-cov = "pytest tests -c config/pytest.ini --cov=src --cov-report=term-missing --cov-report=html"
 
 # Combined tasks
 check = ["lint", "typecheck", "security", "deadcode"]

--- a/src/unblu_mcp/__init__.py
+++ b/src/unblu_mcp/__init__.py
@@ -8,6 +8,17 @@ from __future__ import annotations
 # Also expose at package level for entry point
 from unblu_mcp._internal import cli
 from unblu_mcp._internal.cli import get_parser, main
+from unblu_mcp._internal.providers import (
+    ConnectionConfig,
+    ConnectionProvider,
+    DefaultConnectionProvider,
+)
+from unblu_mcp._internal.providers_k8s import (
+    DEFAULT_ENVIRONMENTS,
+    K8sConnectionProvider,
+    K8sEnvironmentConfig,
+    detect_environment_from_context,
+)
 from unblu_mcp._internal.server import (
     OperationInfo,
     OperationSchema,
@@ -18,12 +29,19 @@ from unblu_mcp._internal.server import (
 )
 
 __all__: list[str] = [
+    "DEFAULT_ENVIRONMENTS",
+    "ConnectionConfig",
+    "ConnectionProvider",
+    "DefaultConnectionProvider",
+    "K8sConnectionProvider",
+    "K8sEnvironmentConfig",
     "OperationInfo",
     "OperationSchema",
     "ServiceInfo",
     "UnbluAPIRegistry",
     "cli",
     "create_server",
+    "detect_environment_from_context",
     "get_parser",
     "get_server",
     "main",

--- a/src/unblu_mcp/_internal/providers.py
+++ b/src/unblu_mcp/_internal/providers.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import os
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+
+import httpx
+
+
+@dataclass
+class ConnectionConfig:
+    """Configuration returned by a connection provider."""
+
+    base_url: str
+    """The base URL for API requests (e.g., http://localhost:8084/kop/rest/v4)."""
+
+    headers: dict[str, str] = field(default_factory=dict)
+    """Additional headers to include in all requests (e.g., trusted headers)."""
+
+    auth: httpx.Auth | None = None
+    """Optional httpx auth handler for basic auth, etc."""
+
+    timeout: float = 30.0
+    """Request timeout in seconds."""
+
+
+class ConnectionProvider(ABC):
+    """Abstract base class for connection providers.
+
+    Connection providers handle the complexity of connecting to Unblu deployments
+    in various environments. They can:
+
+    - Start/stop port-forwards or tunnels
+    - Manage authentication (API keys, basic auth, trusted headers)
+    - Handle environment switching
+    - Refresh credentials when needed
+
+    Example implementation for Kubernetes:
+
+        class K8sConnectionProvider(ConnectionProvider):
+            def __init__(self, environment: str = "t1"):
+                self.environment = environment
+                self._port_forward_process = None
+
+            async def setup(self) -> None:
+                # Start kubectl port-forward
+                ...
+
+            async def teardown(self) -> None:
+                # Stop port-forward
+                ...
+
+            def get_config(self) -> ConnectionConfig:
+                return ConnectionConfig(
+                    base_url=f"http://localhost:{self.port}/kop/rest/v4",
+                    headers={
+                        "x-unblu-trusted-user-id": "superadmin",
+                        "x-unblu-trusted-user-role": "SUPER_ADMIN",
+                    },
+                )
+    """
+
+    @abstractmethod
+    async def setup(self) -> None:
+        """Initialize the connection (start port-forward, refresh auth, etc.).
+
+        Called once when the MCP server starts, before any API requests.
+        Should be idempotent - safe to call multiple times.
+        """
+
+    @abstractmethod
+    async def teardown(self) -> None:
+        """Clean up resources (stop port-forward, close connections, etc.).
+
+        Called when the MCP server shuts down.
+        Should be safe to call even if setup() was never called.
+        """
+
+    @abstractmethod
+    def get_config(self) -> ConnectionConfig:
+        """Return the current connection configuration.
+
+        This is called for each API request, allowing dynamic configuration
+        (e.g., refreshing tokens, switching environments).
+
+        Returns:
+            ConnectionConfig with base_url, headers, auth, and timeout.
+        """
+
+    async def health_check(self) -> bool:
+        """Check if the connection is healthy.
+
+        Override this to implement custom health checks (e.g., ping the API).
+
+        Returns:
+            True if the connection is healthy, False otherwise.
+        """
+        return True
+
+
+class DefaultConnectionProvider(ConnectionProvider):
+    """Default provider using environment variables.
+
+    This is the standard provider for direct connections to Unblu Cloud
+    or self-hosted deployments with direct network access.
+
+    Environment variables:
+        UNBLU_BASE_URL: API base URL (default: https://unblu.cloud/app/rest/v4)
+        UNBLU_API_KEY: Bearer token for API key auth
+        UNBLU_USERNAME: Username for basic auth
+        UNBLU_PASSWORD: Password for basic auth
+        UNBLU_TRUSTED_HEADERS: Trusted headers (format: "key:value,key:value")
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        trusted_headers: dict[str, str] | None = None,
+    ) -> None:
+        self._base_url = base_url
+        self._api_key = api_key
+        self._username = username
+        self._password = password
+        self._trusted_headers = trusted_headers
+
+    async def setup(self) -> None:
+        """No setup needed for direct connections."""
+
+    async def teardown(self) -> None:
+        """No teardown needed for direct connections."""
+
+    def get_config(self) -> ConnectionConfig:
+        """Build config from environment variables and constructor args."""
+        # Load from environment if not provided
+        base_url = self._base_url or os.environ.get(
+            "UNBLU_BASE_URL", "https://unblu.cloud/app/rest/v4"
+        )
+        api_key = self._api_key or os.environ.get("UNBLU_API_KEY")
+        username = self._username or os.environ.get("UNBLU_USERNAME")
+        password = self._password or os.environ.get("UNBLU_PASSWORD")
+        trusted_headers = self._trusted_headers
+        if trusted_headers is None:
+            trusted_headers = _parse_trusted_headers(
+                os.environ.get("UNBLU_TRUSTED_HEADERS")
+            )
+
+        # Build headers and auth
+        headers: dict[str, str] = {}
+        auth: httpx.Auth | None = None
+
+        if trusted_headers:
+            headers.update(trusted_headers)
+        elif api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        elif username and password:
+            auth = httpx.BasicAuth(username, password)
+
+        return ConnectionConfig(
+            base_url=base_url,
+            headers=headers,
+            auth=auth,
+        )
+
+
+def _parse_trusted_headers(headers_str: str | None) -> dict[str, str]:
+    """Parse trusted headers from comma-separated key:value pairs."""
+    if not headers_str:
+        return {}
+    headers = {}
+    for pair in headers_str.split(","):
+        if ":" in pair:
+            key, value = pair.split(":", 1)
+            headers[key.strip()] = value.strip()
+    return headers

--- a/src/unblu_mcp/_internal/providers_k8s.py
+++ b/src/unblu_mcp/_internal/providers_k8s.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import asyncio
+import shutil
+import socket
+import subprocess
+from dataclasses import dataclass
+
+from unblu_mcp._internal.providers import ConnectionConfig, ConnectionProvider
+
+
+@dataclass
+class K8sEnvironmentConfig:
+    """Configuration for a Kubernetes environment."""
+
+    name: str
+    """Environment name (e.g., t1, t2, p1, e1)."""
+
+    local_port: int
+    """Local port for port-forwarding."""
+
+    namespace: str
+    """Kubernetes namespace."""
+
+    service: str = "haproxy"
+    """Kubernetes service name."""
+
+    service_port: int = 8080
+    """Service port to forward."""
+
+    api_path: str = "/kop/rest/v4"
+    """API path prefix."""
+
+
+# Default environment configurations
+DEFAULT_ENVIRONMENTS: dict[str, K8sEnvironmentConfig] = {
+    "t1": K8sEnvironmentConfig(name="t1", local_port=8084, namespace="appl-kop-t1"),
+    "t2": K8sEnvironmentConfig(name="t2", local_port=8085, namespace="appl-kop-t2"),
+    "p1": K8sEnvironmentConfig(name="p1", local_port=8086, namespace="appl-kop-p1"),
+    "e1": K8sEnvironmentConfig(name="e1", local_port=8087, namespace="appl-kop-e1"),
+}
+
+
+class K8sConnectionProvider(ConnectionProvider):
+    """Connection provider for Kubernetes deployments using port-forwarding.
+
+    This provider:
+    - Automatically starts kubectl port-forward on setup
+    - Cleans up the port-forward process on teardown
+    - Configures trusted headers authentication
+    - Supports multiple environments with different ports
+
+    Args:
+        environment: Environment name (t1, t2, p1, e1) or custom K8sEnvironmentConfig.
+        trusted_user_id: User ID for trusted headers auth (default: superadmin).
+        trusted_user_role: User role for trusted headers auth (default: SUPER_ADMIN).
+        environments: Custom environment configurations (overrides defaults).
+
+    Example:
+        provider = K8sConnectionProvider(environment="t1")
+        await provider.setup()  # Starts port-forward
+        config = provider.get_config()  # Returns connection config
+        await provider.teardown()  # Stops port-forward
+    """
+
+    def __init__(
+        self,
+        environment: str | K8sEnvironmentConfig = "t1",
+        trusted_user_id: str = "superadmin",
+        trusted_user_role: str = "SUPER_ADMIN",
+        environments: dict[str, K8sEnvironmentConfig] | None = None,
+    ) -> None:
+        self._environments = environments or DEFAULT_ENVIRONMENTS
+
+        if isinstance(environment, str):
+            if environment not in self._environments:
+                valid = ", ".join(self._environments.keys())
+                msg = f"Unknown environment '{environment}'. Valid: {valid}"
+                raise ValueError(msg)
+            self._env_config = self._environments[environment]
+        else:
+            self._env_config = environment
+
+        self._trusted_user_id = trusted_user_id
+        self._trusted_user_role = trusted_user_role
+        self._port_forward_process: subprocess.Popen[bytes] | None = None
+
+    @property
+    def environment(self) -> str:
+        """Return the current environment name."""
+        return self._env_config.name
+
+    @property
+    def local_port(self) -> int:
+        """Return the local port for this environment."""
+        return self._env_config.local_port
+
+    async def setup(self) -> None:
+        """Start kubectl port-forward if not already running."""
+        if self._is_port_in_use():
+            # Port-forward already running (maybe from another process)
+            return
+
+        if not shutil.which("kubectl"):
+            msg = "kubectl not found in PATH"
+            raise RuntimeError(msg)
+
+        cmd = [
+            "kubectl",
+            "port-forward",
+            "-n",
+            self._env_config.namespace,
+            f"svc/{self._env_config.service}",
+            f"{self._env_config.local_port}:{self._env_config.service_port}",
+        ]
+
+        self._port_forward_process = subprocess.Popen(  # noqa: S603
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        # Wait for port to become available
+        for _ in range(20):  # 10 seconds max
+            await asyncio.sleep(0.5)
+            if self._is_port_in_use():
+                return
+
+        # Failed to start
+        self._port_forward_process.kill()
+        self._port_forward_process = None
+        msg = f"Failed to start port-forward to {self._env_config.namespace}"
+        raise RuntimeError(msg)
+
+    async def teardown(self) -> None:
+        """Stop the port-forward process if we started it."""
+        if self._port_forward_process is not None:
+            self._port_forward_process.terminate()
+            try:
+                self._port_forward_process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._port_forward_process.kill()
+            self._port_forward_process = None
+
+    def get_config(self) -> ConnectionConfig:
+        """Return connection config with trusted headers."""
+        return ConnectionConfig(
+            base_url=f"http://localhost:{self._env_config.local_port}{self._env_config.api_path}",
+            headers={
+                "x-unblu-trusted-user-id": self._trusted_user_id,
+                "x-unblu-trusted-user-role": self._trusted_user_role,
+            },
+        )
+
+    async def health_check(self) -> bool:
+        """Check if the port-forward is healthy."""
+        return self._is_port_in_use()
+
+    def _is_port_in_use(self) -> bool:
+        """Check if the local port is in use."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            return s.connect_ex(("localhost", self._env_config.local_port)) == 0
+
+
+def detect_environment_from_context() -> str | None:
+    """Detect the environment from the current kubectl context.
+
+    Returns:
+        Environment name (t1, t2, p1, e1) or None if not detected.
+    """
+    try:
+        result = subprocess.run(
+            ["kubectl", "config", "current-context"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        context = result.stdout.strip()
+
+        # Match common patterns
+        for env in ["t1", "t2", "p1", "e1"]:
+            if f"-{env}-" in context or context.endswith(f"-{env}"):
+                return env
+        return None  # noqa: TRY300
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None

--- a/tests/test_providers_k8s.py
+++ b/tests/test_providers_k8s.py
@@ -1,0 +1,287 @@
+"""Tests for the Kubernetes connection provider."""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from unblu_mcp._internal.providers_k8s import (
+    DEFAULT_ENVIRONMENTS,
+    K8sConnectionProvider,
+    K8sEnvironmentConfig,
+    detect_environment_from_context,
+)
+
+
+class TestK8sEnvironmentConfig:
+    """Tests for K8sEnvironmentConfig dataclass."""
+
+    def test_default_values(self) -> None:
+        """Config has sensible defaults."""
+        config = K8sEnvironmentConfig(name="test", local_port=8080, namespace="test-ns")
+        assert config.service == "haproxy"
+        assert config.service_port == 8080
+        assert config.api_path == "/kop/rest/v4"
+
+    def test_custom_values(self) -> None:
+        """Config accepts custom values."""
+        config = K8sEnvironmentConfig(
+            name="custom",
+            local_port=9000,
+            namespace="custom-ns",
+            service="nginx",
+            service_port=443,
+            api_path="/api/v1",
+        )
+        assert config.name == "custom"
+        assert config.local_port == 9000
+        assert config.namespace == "custom-ns"
+        assert config.service == "nginx"
+        assert config.service_port == 443
+        assert config.api_path == "/api/v1"
+
+
+class TestDefaultEnvironments:
+    """Tests for default environment configurations."""
+
+    def test_all_environments_defined(self) -> None:
+        """All expected environments are defined."""
+        assert "t1" in DEFAULT_ENVIRONMENTS
+        assert "t2" in DEFAULT_ENVIRONMENTS
+        assert "p1" in DEFAULT_ENVIRONMENTS
+        assert "e1" in DEFAULT_ENVIRONMENTS
+
+    def test_environments_have_unique_ports(self) -> None:
+        """Each environment has a unique local port."""
+        ports = [env.local_port for env in DEFAULT_ENVIRONMENTS.values()]
+        assert len(ports) == len(set(ports))
+
+    def test_t1_config(self) -> None:
+        """T1 environment has correct configuration."""
+        t1 = DEFAULT_ENVIRONMENTS["t1"]
+        assert t1.name == "t1"
+        assert t1.local_port == 8084
+        assert t1.namespace == "appl-kop-t1"
+
+
+class TestK8sConnectionProvider:
+    """Tests for K8sConnectionProvider."""
+
+    def test_init_with_string_environment(self) -> None:
+        """Provider initializes with string environment name."""
+        provider = K8sConnectionProvider(environment="t1")
+        assert provider.environment == "t1"
+        assert provider.local_port == 8084
+
+    def test_init_with_config_object(self) -> None:
+        """Provider initializes with K8sEnvironmentConfig object."""
+        config = K8sEnvironmentConfig(name="custom", local_port=9999, namespace="custom-ns")
+        provider = K8sConnectionProvider(environment=config)
+        assert provider.environment == "custom"
+        assert provider.local_port == 9999
+
+    def test_init_unknown_environment_raises(self) -> None:
+        """Provider raises ValueError for unknown environment."""
+        with pytest.raises(ValueError, match="Unknown environment 'invalid'"):
+            K8sConnectionProvider(environment="invalid")
+
+    def test_init_custom_environments(self) -> None:
+        """Provider accepts custom environment configurations."""
+        custom_envs = {
+            "dev": K8sEnvironmentConfig(name="dev", local_port=8000, namespace="dev-ns"),
+        }
+        provider = K8sConnectionProvider(environment="dev", environments=custom_envs)
+        assert provider.environment == "dev"
+        assert provider.local_port == 8000
+
+    def test_get_config_returns_connection_config(self) -> None:
+        """get_config returns properly configured ConnectionConfig."""
+        provider = K8sConnectionProvider(
+            environment="t1",
+            trusted_user_id="testuser",
+            trusted_user_role="ADMIN",
+        )
+        config = provider.get_config()
+
+        assert config.base_url == "http://localhost:8084/kop/rest/v4"
+        assert config.headers["x-unblu-trusted-user-id"] == "testuser"
+        assert config.headers["x-unblu-trusted-user-role"] == "ADMIN"
+
+    def test_get_config_default_trusted_headers(self) -> None:
+        """get_config uses default trusted headers."""
+        provider = K8sConnectionProvider(environment="t1")
+        config = provider.get_config()
+
+        assert config.headers["x-unblu-trusted-user-id"] == "superadmin"
+        assert config.headers["x-unblu-trusted-user-role"] == "SUPER_ADMIN"
+
+    @pytest.mark.asyncio
+    async def test_setup_port_already_in_use(self) -> None:
+        """setup() returns early if port is already in use."""
+        provider = K8sConnectionProvider(environment="t1")
+
+        with patch.object(provider, "_is_port_in_use", return_value=True):
+            await provider.setup()
+            # Should not start a new process
+            assert provider._port_forward_process is None
+
+    @pytest.mark.asyncio
+    async def test_setup_kubectl_not_found(self) -> None:
+        """setup() raises RuntimeError if kubectl not found."""
+        provider = K8sConnectionProvider(environment="t1")
+
+        with (
+            patch.object(provider, "_is_port_in_use", return_value=False),
+            patch("shutil.which", return_value=None),
+            pytest.raises(RuntimeError, match="kubectl not found"),
+        ):
+            await provider.setup()
+
+    @pytest.mark.asyncio
+    async def test_setup_starts_port_forward(self) -> None:
+        """setup() starts kubectl port-forward process."""
+        provider = K8sConnectionProvider(environment="t1")
+        mock_process = MagicMock()
+
+        # First call returns False (port not in use), subsequent calls return True (port ready)
+        port_check_results = [False, True]
+
+        with (
+            patch.object(provider, "_is_port_in_use", side_effect=port_check_results),
+            patch("shutil.which", return_value="/usr/bin/kubectl"),
+            patch("subprocess.Popen", return_value=mock_process) as mock_popen,
+        ):
+            await provider.setup()
+
+            mock_popen.assert_called_once()
+            call_args = mock_popen.call_args[0][0]
+            assert "kubectl" in call_args
+            assert "port-forward" in call_args
+            assert "-n" in call_args
+            assert "appl-kop-t1" in call_args
+
+    @pytest.mark.asyncio
+    async def test_setup_timeout_kills_process(self) -> None:
+        """setup() kills process and raises if port never becomes available."""
+        provider = K8sConnectionProvider(environment="t1")
+        mock_process = MagicMock()
+
+        with (
+            patch.object(provider, "_is_port_in_use", return_value=False),
+            patch("shutil.which", return_value="/usr/bin/kubectl"),
+            patch("subprocess.Popen", return_value=mock_process),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to start port-forward"):
+                await provider.setup()
+
+            mock_process.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_teardown_terminates_process(self) -> None:
+        """teardown() terminates the port-forward process."""
+        provider = K8sConnectionProvider(environment="t1")
+        mock_process = MagicMock()
+        provider._port_forward_process = mock_process
+
+        await provider.teardown()
+
+        mock_process.terminate.assert_called_once()
+        mock_process.wait.assert_called_once_with(timeout=5)
+        assert provider._port_forward_process is None
+
+    @pytest.mark.asyncio
+    async def test_teardown_kills_on_timeout(self) -> None:
+        """teardown() kills process if terminate times out."""
+        provider = K8sConnectionProvider(environment="t1")
+        mock_process = MagicMock()
+        mock_process.wait.side_effect = subprocess.TimeoutExpired(cmd="kubectl", timeout=5)
+        provider._port_forward_process = mock_process
+
+        await provider.teardown()
+
+        mock_process.terminate.assert_called_once()
+        mock_process.kill.assert_called_once()
+        assert provider._port_forward_process is None
+
+    @pytest.mark.asyncio
+    async def test_teardown_no_process(self) -> None:
+        """teardown() does nothing if no process was started."""
+        provider = K8sConnectionProvider(environment="t1")
+        provider._port_forward_process = None
+
+        await provider.teardown()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_health_check_delegates_to_port_check(self) -> None:
+        """health_check() returns port availability status."""
+        provider = K8sConnectionProvider(environment="t1")
+
+        with patch.object(provider, "_is_port_in_use", return_value=True):
+            assert await provider.health_check() is True
+
+        with patch.object(provider, "_is_port_in_use", return_value=False):
+            assert await provider.health_check() is False
+
+    def test_is_port_in_use_available_port(self) -> None:
+        """_is_port_in_use returns False for available port."""
+        provider = K8sConnectionProvider(environment="t1")
+        # Use a high port that's unlikely to be in use
+        provider._env_config = K8sEnvironmentConfig(name="test", local_port=59999, namespace="test")
+        assert provider._is_port_in_use() is False
+
+    def test_is_port_in_use_bound_port(self) -> None:
+        """_is_port_in_use returns True for bound port."""
+        provider = K8sConnectionProvider(environment="t1")
+
+        # Bind a port temporarily
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("localhost", 0))
+            port = s.getsockname()[1]
+            s.listen(1)
+
+            provider._env_config = K8sEnvironmentConfig(name="test", local_port=port, namespace="test")
+            assert provider._is_port_in_use() is True
+
+
+class TestDetectEnvironmentFromContext:
+    """Tests for detect_environment_from_context function."""
+
+    def test_detects_t1_environment(self) -> None:
+        """Detects t1 from context name."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="cluster-t1-context\n")
+            assert detect_environment_from_context() == "t1"
+
+    def test_detects_environment_with_suffix(self) -> None:
+        """Detects environment from context ending with env name."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="my-cluster-p1\n")
+            assert detect_environment_from_context() == "p1"
+
+    def test_detects_environment_with_dash_pattern(self) -> None:
+        """Detects environment from -env- pattern in context."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="prefix-e1-suffix\n")
+            assert detect_environment_from_context() == "e1"
+
+    def test_returns_none_for_unknown_context(self) -> None:
+        """Returns None if context doesn't match any environment."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="production-cluster\n")
+            assert detect_environment_from_context() is None
+
+    def test_returns_none_on_subprocess_error(self) -> None:
+        """Returns None if kubectl command fails."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(1, "kubectl")
+            assert detect_environment_from_context() is None
+
+    def test_returns_none_if_kubectl_not_found(self) -> None:
+        """Returns None if kubectl is not installed."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError()
+            assert detect_environment_from_context() is None


### PR DESCRIPTION
### For reviewers

- [x] I used AI and thoroughly reviewed every code/docs change

### Description of the change

Implements a **connection provider plugin system** for enterprise deployments that require complex connectivity (Kubernetes port-forwarding, trusted headers auth, etc.).

#### New Components

- **`ConnectionProvider`** - Abstract base class defining the provider interface with `setup()`, `teardown()`, `get_config()`, and `health_check()` methods
- **`ConnectionConfig`** - Dataclass containing `base_url`, `headers`, `auth`, and `timeout` for API requests
- **`DefaultConnectionProvider`** - Standard provider using environment variables (`UNBLU_BASE_URL`, `UNBLU_API_KEY`, etc.)
- **`K8sConnectionProvider`** - Kubernetes provider with automatic `kubectl port-forward` management and trusted headers auth

#### Features

- Automatic port-forward lifecycle management (start on setup, cleanup on teardown)
- Support for multiple K8s environments (t1, t2, p1, e1) with configurable ports
- Trusted headers authentication for internal deployments
- Environment detection from kubectl context
- Comprehensive test coverage (287 lines of tests)

#### Also includes

- FastMCP 2.14.0 upgrade with MCP annotations and response caching
- Bandit security exclusions for intentional subprocess usage

### Relevant resources

- Closes #17

Closes #17