### PR TITLE
chore: add docs workflow and switch CI to Blacksmith runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,12 @@
+self-hosted-runner:
+  labels:
+    - blacksmith-2vcpu-ubuntu-2404
+    - blacksmith-4vcpu-ubuntu-2404
+    - blacksmith-8vcpu-ubuntu-2404
+    - blacksmith-16vcpu-ubuntu-2404
+    - blacksmith-32vcpu-ubuntu-2404
+    - blacksmith-2vcpu-windows-2025
+    - blacksmith-4vcpu-windows-2025
+    - blacksmith-8vcpu-windows-2025
+    - blacksmith-16vcpu-windows-2025
+    - blacksmith-32vcpu-windows-2025

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,21 @@ jobs:
     strategy:
       matrix:
         os:
-        - ubuntu-latest
-        - macos-latest
-        - blacksmith-4vcpu-windows-2025
+        - ubuntu
+        - macos
+        - windows
         python-version:
         - "3.13"
         - "3.14"
+        include:
+        - os: ubuntu
+          runner: blacksmith-4vcpu-ubuntu-2404
+        - os: macos
+          runner: macos-latest
+        - os: windows
+          runner: blacksmith-4vcpu-windows-2025
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
 
     steps:
     - name: Checkout
@@ -79,7 +86,7 @@ jobs:
 
     - name: Store objects inventory for tests
       uses: actions/upload-artifact@v6
-      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' }}
+      if: ${{ matrix.os == 'ubuntu' && matrix.python-version == '3.13' }}
       with:
         name: objects.inv
         path: site/objects.inv
@@ -91,21 +98,28 @@ jobs:
     strategy:
       matrix:
         os:
-        - ubuntu-latest
-        - macos-latest
-        - blacksmith-4vcpu-windows-2025
+        - ubuntu
+        - macos
+        - windows
         python-version:
         - "3.13"
         - "3.14"
         resolution:
         - highest
         - lowest-direct
+        include:
+        - os: ubuntu
+          runner: blacksmith-4vcpu-ubuntu-2404
+        - os: macos
+          runner: macos-latest
+        - os: windows
+          runner: blacksmith-4vcpu-windows-2025
         exclude:
-        - os: macos-latest
+        - os: macos
           resolution: lowest-direct
-        - os: blacksmith-4vcpu-windows-2025
+        - os: windows
           resolution: lowest-direct
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     continue-on-error: true
 
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,56 @@
+name: docs
+
+"on":
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup uv and Python
+        uses: astral-sh/setup-uv@v7.1.5
+        with:
+          python-version: "3.13"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --group docs
+
+      - name: Build docs
+        run: uv run mkdocs build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+#   deploy:
+#     environment:
+#       name: github-pages
+#       url: ${{ steps.deployment.outputs.page_url }}
+#     runs-on: blacksmith-4vcpu-ubuntu-2404
+#     needs: build
+#     steps:
+#       - name: Deploy to GitHub Pages
+#         id: deployment
+#         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Adds documentation build workflow and improves CI runner configuration.

## Changes

### Documentation Workflow (`.github/workflows/docs.yml`)
- Builds MkDocs documentation on push to main
- Uploads build artifact for future GitHub Pages deployment
- Deploy step commented out pending repo going public (see #30)

### CI Improvements (`.github/workflows/ci.yml`)
- Refactored OS matrix to use logical names (`ubuntu`, `macos`, `windows`) with `include` mappings to runners
- Ubuntu and Windows now use Blacksmith runners for faster builds
- macOS stays on GitHub runners (Blacksmith doesn't offer macOS)

### Actionlint Configuration (`.github/actionlint.yaml`)
- Whitelists Blacksmith runner labels to pass pre-commit actionlint checks

## Runner Configuration

| OS | Runner |
|----|--------|
| Ubuntu | `blacksmith-4vcpu-ubuntu-2404` |
| Windows | `blacksmith-4vcpu-windows-2025` (beta) |
| macOS | `macos-latest` |

## Related

- #30 - Publish documentation as GitHub Pages (blocked on public repo)
- #32 - Initial Blacksmith migration (merged)