### PR TITLE
feat: add LoggingMiddleware for observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Built with [FastMCP 2.14+](https://github.com/jlowin/fastmcp), leveraging cuttin
 - **MCP Annotations**: Tools include `readOnlyHint`, `destructiveHint`, and `openWorldHint` metadata for smarter AI decision-making
 - **Response Caching**: Discovery tools cache results via FastMCP middleware for faster repeated queries
 - **Policy-Based Authorization**: Optional [Eunomia](https://github.com/whataboutyou-ai/eunomia) integration for controlling which API operations are allowed
+- **Built-in Logging**: Automatic file-based logging with daily rotation for debugging and usage analysis
 - **MCP 2025-11-25 Spec**: Full support for the latest Model Context Protocol specification
 
 ## Installation
@@ -163,6 +164,42 @@ unblu-mcp --version
 # Show debug info
 unblu-mcp --debug-info
 ```
+
+## Logging & Observability
+
+The server automatically logs all tool calls to help with debugging and usage analysis.
+
+### Log Location
+
+Logs are written to `~/.unblu-mcp/logs/` with daily rotation:
+
+```
+~/.unblu-mcp/logs/
+├── unblu-mcp-2025-01-15.log
+├── unblu-mcp-2025-01-14.log
+└── ...
+```
+
+### Configuration
+
+| Environment Variable | Description |
+|---------------------|-------------|
+| `UNBLU_MCP_LOG_DIR` | Custom log directory (default: `~/.unblu-mcp/logs`) |
+| `UNBLU_MCP_LOG_DISABLE` | Set to `1`, `true`, or `yes` to disable file logging |
+
+### Log Format
+
+```
+2025-01-15 14:30:22 | INFO     | fastmcp | tools/call request: call_api(operation_id="conversationsGetById", ...)
+```
+
+Logs include:
+- Timestamp (UTC)
+- Log level
+- Tool name and arguments
+- Response summaries
+
+Logs are retained for 30 days and automatically rotated at midnight UTC.
 
 ## Safety & Authorization
 

--- a/src/unblu_mcp/_internal/logging.py
+++ b/src/unblu_mcp/_internal/logging.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
+
+_DEFAULT_LOG_DIR = Path.home() / ".unblu-mcp" / "logs"
+_LOG_DIR_ENV_VAR = "UNBLU_MCP_LOG_DIR"
+_LOG_RETENTION_DAYS = 30
+
+
+def _configure_file_logging(log_dir: Path | str | None = None) -> Path | None:
+    """Configure file-based logging with daily rotation.
+
+    Creates a log file with format: unblu-mcp-YYYY-MM-DD.log
+    Rotates daily at midnight and keeps LOG_RETENTION_DAYS days of logs.
+
+    Args:
+        log_dir: Directory for log files. Defaults to UNBLU_MCP_LOG_DIR env var
+                 or ~/.unblu-mcp/logs if not set.
+
+    Returns:
+        Path to the current log file, or None if logging is disabled.
+    """
+    # Check for explicit disable
+    if os.environ.get("UNBLU_MCP_LOG_DISABLE", "").lower() in ("1", "true", "yes"):
+        return None
+
+    if log_dir is None:
+        log_dir = os.environ.get(_LOG_DIR_ENV_VAR)
+
+    log_dir = _DEFAULT_LOG_DIR if log_dir is None else Path(log_dir)
+
+    # Create log directory if it doesn't exist
+    log_dir = Path(log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create log filename with today's date
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    log_file = log_dir / f"unblu-mcp-{today}.log"
+
+    # Configure the root logger for fastmcp
+    logger = logging.getLogger("fastmcp")
+
+    # Avoid adding duplicate handlers
+    if any(isinstance(h, TimedRotatingFileHandler) for h in logger.handlers):
+        return log_file
+
+    # Create timed rotating file handler
+    # Rotates at midnight, keeps LOG_RETENTION_DAYS backups
+    handler = TimedRotatingFileHandler(
+        filename=log_file,
+        when="midnight",
+        interval=1,
+        backupCount=_LOG_RETENTION_DAYS,
+        encoding="utf-8",
+        utc=True,
+    )
+
+    # Set format
+    formatter = logging.Formatter(
+        fmt="%(asctime)s | %(levelname)-8s | %(name)s | %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    handler.setFormatter(formatter)
+
+    # Add handler to fastmcp logger
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+
+    return log_file

--- a/src/unblu_mcp/_internal/server.py
+++ b/src/unblu_mcp/_internal/server.py
@@ -8,7 +8,10 @@ from typing import TYPE_CHECKING, Any
 import httpx
 from fastmcp import FastMCP
 from fastmcp.server.middleware.caching import CallToolSettings, ResponseCachingMiddleware
+from fastmcp.server.middleware.logging import LoggingMiddleware
 from pydantic import BaseModel, Field
+
+from unblu_mcp._internal.logging import _configure_file_logging
 
 if TYPE_CHECKING:
     from unblu_mcp._internal.providers import ConnectionProvider
@@ -314,6 +317,20 @@ Example workflow:
                     "get_operation_schema",
                 ],
             ),
+        )
+    )
+
+    # Configure file-based logging with daily rotation
+    # Logs are written to ~/.unblu-mcp/logs/unblu-mcp-YYYY-MM-DD.log
+    # Can be customized via UNBLU_MCP_LOG_DIR env var or disabled with UNBLU_MCP_LOG_DISABLE=1
+    _configure_file_logging()
+
+    # Add logging middleware for observability
+    # Logs tool calls with payloads to help identify usage patterns and errors
+    mcp.add_middleware(
+        LoggingMiddleware(
+            include_payloads=True,
+            max_payload_length=1000,
         )
     )
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime
+from logging.handlers import TimedRotatingFileHandler
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from unblu_mcp._internal.logging import _configure_file_logging
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestConfigureFileLogging:
+    """Tests for _configure_file_logging function."""
+
+    def test_creates_log_directory(self, tmp_path: Path) -> None:
+        """Log directory is created if it doesn't exist."""
+        log_dir = tmp_path / "logs"
+        assert not log_dir.exists()
+
+        result = _configure_file_logging(log_dir=log_dir)
+
+        assert log_dir.exists()
+        assert result is not None
+        assert result.parent == log_dir
+
+    def test_log_file_has_date_format(self, tmp_path: Path) -> None:
+        """Log file name includes today's date in YYYY-MM-DD format."""
+        result = _configure_file_logging(log_dir=tmp_path)
+
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
+        assert result is not None
+        assert result.name == f"unblu-mcp-{today}.log"
+
+    def test_adds_handler_to_fastmcp_logger(self, tmp_path: Path) -> None:
+        """A TimedRotatingFileHandler is added to the fastmcp logger."""
+        logger = logging.getLogger("fastmcp")
+        initial_handlers = len(logger.handlers)
+
+        _configure_file_logging(log_dir=tmp_path)
+
+        assert len(logger.handlers) > initial_handlers
+        assert any(isinstance(h, TimedRotatingFileHandler) for h in logger.handlers)
+
+    def test_does_not_add_duplicate_handlers(self, tmp_path: Path) -> None:
+        """Calling configure twice doesn't add duplicate handlers."""
+        logger = logging.getLogger("fastmcp")
+
+        _configure_file_logging(log_dir=tmp_path)
+        handler_count = len(logger.handlers)
+
+        _configure_file_logging(log_dir=tmp_path)
+        assert len(logger.handlers) == handler_count
+
+    def test_disabled_via_env_var(self, tmp_path: Path) -> None:
+        """Logging can be disabled via UNBLU_MCP_LOG_DISABLE env var."""
+        with patch.dict(os.environ, {"UNBLU_MCP_LOG_DISABLE": "1"}):
+            result = _configure_file_logging(log_dir=tmp_path)
+
+        assert result is None
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "TRUE", "Yes"])
+    def test_disabled_accepts_various_truthy_values(self, tmp_path: Path, value: str) -> None:
+        """Various truthy values disable logging."""
+        with patch.dict(os.environ, {"UNBLU_MCP_LOG_DISABLE": value}):
+            result = _configure_file_logging(log_dir=tmp_path)
+
+        assert result is None
+
+    def test_custom_log_dir_via_env_var(self, tmp_path: Path) -> None:
+        """Log directory can be set via UNBLU_MCP_LOG_DIR env var."""
+        custom_dir = tmp_path / "custom_logs"
+        with patch.dict(os.environ, {"UNBLU_MCP_LOG_DIR": str(custom_dir)}):
+            result = _configure_file_logging()
+
+        assert result is not None
+        assert result.parent == custom_dir
+
+    def test_explicit_log_dir_overrides_env_var(self, tmp_path: Path) -> None:
+        """Explicit log_dir parameter takes precedence over env var."""
+        env_dir = tmp_path / "env_logs"
+        explicit_dir = tmp_path / "explicit_logs"
+
+        with patch.dict(os.environ, {"UNBLU_MCP_LOG_DIR": str(env_dir)}):
+            result = _configure_file_logging(log_dir=explicit_dir)
+
+        assert result is not None
+        assert result.parent == explicit_dir
+
+    def test_log_format_is_correct(self, tmp_path: Path) -> None:
+        """Log format includes timestamp, level, name, and message."""
+        _configure_file_logging(log_dir=tmp_path)
+
+        logger = logging.getLogger("fastmcp")
+        handler = next(h for h in logger.handlers if isinstance(h, TimedRotatingFileHandler))
+
+        assert handler.formatter is not None
+        # Check format string contains expected components
+        fmt = handler.formatter._fmt
+        assert "%(asctime)s" in fmt
+        assert "%(levelname)" in fmt
+        assert "%(name)s" in fmt
+        assert "%(message)s" in fmt
+
+
+@pytest.fixture(autouse=True)
+def cleanup_fastmcp_handlers():  # type: ignore[misc]
+    """Remove any TimedRotatingFileHandler from fastmcp logger after each test."""
+    yield
+    logger = logging.getLogger("fastmcp")
+    for handler in logger.handlers[:]:
+        if isinstance(handler, TimedRotatingFileHandler):
+            handler.close()
+            logger.removeHandler(handler)


### PR DESCRIPTION
## Summary

Adds FastMCP's `LoggingMiddleware` for observability with persistent file logging.

## Changes

### LoggingMiddleware
- Added `LoggingMiddleware` from `fastmcp.server.middleware.logging`
- Configured with `include_payloads=True` and `max_payload_length=1000`

### File Persistence
- Logs written to `~/.unblu-mcp/logs/unblu-mcp-YYYY-MM-DD.log`
- Daily rotation at midnight (UTC)
- Keeps 30 days of logs
- Customizable via `UNBLU_MCP_LOG_DIR` env var
- Disable with `UNBLU_MCP_LOG_DISABLE=1`

### Tests
- 13 new tests for logging module (100% coverage)
- Tests for directory creation, date format, handler management, env var config

## Why

Observability data will inform future improvements:
- Identify which operations are most frequently used
- Spot common error patterns
- Guide poka-yoke (error-proofing) implementation based on real usage

## Related

- #33 - Developer experience backlog (observability was listed as a nice-to-have)