### PR TITLE
fix: restore dated log file format (YYYY-MM-DD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,8 @@ Logs are written to `~/.unblu-mcp/logs/` with daily rotation:
 
 ```
 ~/.unblu-mcp/logs/
-├── unblu-mcp.log          # Current log file
-├── unblu-mcp.log.1        # Yesterday's log
-├── unblu-mcp.log.2        # Day before
+├── unblu-mcp-2025-01-15.log
+├── unblu-mcp-2025-01-14.log
 └── ...
 ```
 

--- a/src/unblu_mcp/_internal/logging.py
+++ b/src/unblu_mcp/_internal/logging.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+from datetime import UTC, datetime
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
 
@@ -13,9 +14,8 @@ _LOG_RETENTION_DAYS = 30
 def _configure_file_logging(log_dir: Path | str | None = None) -> Path | None:
     """Configure file-based logging with daily rotation.
 
-    Creates a log file named unblu-mcp.log that rotates daily at midnight.
-    Rotated files are named unblu-mcp.log.1, unblu-mcp.log.2, etc.
-    Keeps LOG_RETENTION_DAYS days of logs.
+    Creates a log file with format: unblu-mcp-YYYY-MM-DD.log
+    Rotates daily at midnight and keeps LOG_RETENTION_DAYS days of logs.
 
     Args:
         log_dir: Directory for log files. Defaults to UNBLU_MCP_LOG_DIR env var
@@ -38,7 +38,8 @@ def _configure_file_logging(log_dir: Path | str | None = None) -> Path | None:
     log_dir.mkdir(parents=True, exist_ok=True)
 
     # Create log filename with today's date
-    log_file = log_dir / "unblu-mcp.log"
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    log_file = log_dir / f"unblu-mcp-{today}.log"
 
     # Configure the root logger for fastmcp
     logger = logging.getLogger("fastmcp")

--- a/src/unblu_mcp/_internal/providers_k8s.py
+++ b/src/unblu_mcp/_internal/providers_k8s.py
@@ -54,7 +54,7 @@ def _load_environments_from_yaml(path: Path) -> dict[str, K8sEnvironmentConfig]:
     if not path.exists():
         return {}
 
-    with path.open() as f:
+    with path.open(encoding="utf-8") as f:
         data: dict[str, Any] = yaml.safe_load(f) or {}
 
     environments: dict[str, K8sEnvironmentConfig] = {}

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+from datetime import UTC, datetime
 from logging.handlers import TimedRotatingFileHandler
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -28,12 +29,13 @@ class TestConfigureFileLogging:
         assert result is not None
         assert result.parent == log_dir
 
-    def test_log_file_name(self, tmp_path: Path) -> None:
-        """Log file has expected name."""
+    def test_log_file_has_date_format(self, tmp_path: Path) -> None:
+        """Log file name includes today's date in YYYY-MM-DD format."""
         result = _configure_file_logging(log_dir=tmp_path)
 
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
         assert result is not None
-        assert result.name == "unblu-mcp.log"
+        assert result.name == f"unblu-mcp-{today}.log"
 
     def test_adds_handler_to_fastmcp_logger(self, tmp_path: Path) -> None:
         """A TimedRotatingFileHandler is added to the fastmcp logger."""


### PR DESCRIPTION
## Summary

Restores the dated log file format with YYYY-MM-DD in the filename.

### Changes

- Log files now named `unblu-mcp-2025-01-15.log` instead of `unblu-mcp.log`
- Added explicit `encoding="utf-8"` to YAML file loading (fixes Python 3.14 EncodingWarning)
- Updated README and docstrings to reflect the dated format

### Log File Structure

```
~/.unblu-mcp/logs/
├── unblu-mcp-2025-01-15.log
├── unblu-mcp-2025-01-14.log
└── ...
```

Daily rotation at midnight UTC with 30-day retention.