### PR TITLE
fix: use static log filename with handler-managed rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,9 @@ Logs are written to `~/.unblu-mcp/logs/` with daily rotation:
 
 ```
 ~/.unblu-mcp/logs/
-├── unblu-mcp-2025-01-15.log
-├── unblu-mcp-2025-01-14.log
+├── unblu-mcp.log              # Current log
+├── unblu-mcp.log.2025-01-14   # Yesterday
+├── unblu-mcp.log.2025-01-13   # Day before
 └── ...
 ```
 

--- a/src/unblu_mcp/_internal/logging.py
+++ b/src/unblu_mcp/_internal/logging.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import UTC, datetime
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
 
@@ -14,8 +13,9 @@ _LOG_RETENTION_DAYS = 30
 def _configure_file_logging(log_dir: Path | str | None = None) -> Path | None:
     """Configure file-based logging with daily rotation.
 
-    Creates a log file with format: unblu-mcp-YYYY-MM-DD.log
-    Rotates daily at midnight and keeps LOG_RETENTION_DAYS days of logs.
+    Creates unblu-mcp.log which rotates daily at midnight.
+    Rotated files are named unblu-mcp.log.YYYY-MM-DD.
+    Keeps LOG_RETENTION_DAYS days of logs.
 
     Args:
         log_dir: Directory for log files. Defaults to UNBLU_MCP_LOG_DIR env var
@@ -37,9 +37,8 @@ def _configure_file_logging(log_dir: Path | str | None = None) -> Path | None:
     log_dir = Path(log_dir)
     log_dir.mkdir(parents=True, exist_ok=True)
 
-    # Create log filename with today's date
-    today = datetime.now(UTC).strftime("%Y-%m-%d")
-    log_file = log_dir / f"unblu-mcp-{today}.log"
+    # Static filename - TimedRotatingFileHandler manages rotation
+    log_file = log_dir / "unblu-mcp.log"
 
     # Configure the root logger for fastmcp
     logger = logging.getLogger("fastmcp")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import UTC, datetime
 from logging.handlers import TimedRotatingFileHandler
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -29,13 +28,12 @@ class TestConfigureFileLogging:
         assert result is not None
         assert result.parent == log_dir
 
-    def test_log_file_has_date_format(self, tmp_path: Path) -> None:
-        """Log file name includes today's date in YYYY-MM-DD format."""
+    def test_log_file_name(self, tmp_path: Path) -> None:
+        """Log file has static name (handler manages rotation suffixes)."""
         result = _configure_file_logging(log_dir=tmp_path)
 
-        today = datetime.now(UTC).strftime("%Y-%m-%d")
         assert result is not None
-        assert result.name == f"unblu-mcp-{today}.log"
+        assert result.name == "unblu-mcp.log"
 
     def test_adds_handler_to_fastmcp_logger(self, tmp_path: Path) -> None:
         """A TimedRotatingFileHandler is added to the fastmcp logger."""


### PR DESCRIPTION
## Summary

Fixes log file rotation to work correctly with `TimedRotatingFileHandler`.

### Problem

The previous implementation put the date in the filename at startup (`unblu-mcp-2025-01-15.log`), but `TimedRotatingFileHandler` never changes its base filename. In long-running processes, logs would continue writing to the original dated file even after midnight.

### Solution

Use a static filename and let the handler manage rotation suffixes:

```
~/.unblu-mcp/logs/
├── unblu-mcp.log              # Current log
├── unblu-mcp.log.2025-01-14   # Yesterday
├── unblu-mcp.log.2025-01-13   # Day before
└── ...
```

### Changes

- Static filename: `unblu-mcp.log`
- Handler adds date suffix on rotation: `unblu-mcp.log.YYYY-MM-DD`
- Updated README and docstrings