### PR TITLE
chore: reset version to 0.1.0 for fresh start

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.13"
 keywords = []
-version = "1.1.0"
+version = "0.1.0"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",


### PR DESCRIPTION
### For reviewers

- [x] I used AI and thoroughly reviewed every code/docs change

### Description of the change

Reset version from 1.0.2 back to 0.1.0 for a clean public release starting point.

**Background:** The semantic-release workflow automatically bumped versions after merging PRs, creating tags 1.0.0 through 1.1.0. Since we're preparing for initial public release, we want to start fresh at 0.1.0.

**What was done:**
- Deleted GitHub releases (1.0.0, 1.0.1, 1.0.2, 1.1.0)
- Deleted corresponding git tags
- Created new `0.1.0` tag on current main as the baseline
- Reset `pyproject.toml` version to 0.1.0

Now semantic-release will correctly increment from 0.1.0:
- `feat:` commits → 0.2.0, 0.3.0, etc.
- `fix:` commits → 0.1.1, 0.1.2, etc.

### Relevant resources

- Part of #20 (PyPI publication prep)
- Related to #44 (PyPI publishing infrastructure)