### PR TITLE
chore: fix semantic-release to start at 0.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.13"
 keywords = []
-version = "1.0.0"
+version = "0.1.0"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -146,6 +146,7 @@ branch = "main"
 build_command = "uv build"
 commit_message = "chore(release): {version}"
 tag_format = "{version}"
+major_on_zero = false
 
 [tool.semantic_release.changelog]
 template_dir = "templates"


### PR DESCRIPTION
### For reviewers

- [x] I used AI and thoroughly reviewed every code/docs change

### Description of the change

Fix semantic-release configuration to properly start versioning at 0.1.0.

**Problem:** Semantic-release was ignoring our `0.1.0` tag and auto-bumping to `1.0.0` on every push to main.

**Solution:**
- Add `major_on_zero = false` to `[tool.semantic_release]` config
- Reset version back to `0.1.0`

**After this change:**
- `feat:` commits → 0.2.0, 0.3.0, etc. (minor bumps)
- `fix:`/`perf:` commits → 0.1.1, 0.1.2, etc. (patch bumps)
- Breaking changes stay in 0.x until we explicitly release 1.0.0

### Relevant resources

- Part of #20 (PyPI publication prep)
- Related to #44 (PyPI publishing infrastructure)