### PR TITLE
chore: disable auto-release and reset to 0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: release
 
 "on":
-  push:
-    branches:
-      - main
+  # Disabled auto-release until 0.1.0 tag exists - use workflow_dispatch to trigger manually
+  # push:
+  #   branches:
+  #     - main
   workflow_dispatch:
 
 permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.13"
 keywords = []
-version = "1.0.0"
+version = "0.1.0"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",


### PR DESCRIPTION
### For reviewers

- [x] I used AI and thoroughly reviewed every code/docs change

### Description of the change

Disable automatic release workflow to break the cycle of semantic-release defaulting to 1.0.0.

**Problem:** Semantic-release defaults to 1.0.0 when no tags exist, ignoring `major_on_zero = false` (that setting only affects *subsequent* releases).

**Solution:**
1. Disable automatic release on push to main
2. Reset version to 0.1.0
3. After merge, manually create `0.1.0` tag
4. Then re-enable automatic releases in a follow-up PR

**Next steps after merge:**
```bash
git tag 0.1.0 && git push origin 0.1.0
```
Then re-enable the push trigger in release.yml.

### Relevant resources

- Part of #20 (PyPI publication prep)
- Related to #44 (PyPI publishing infrastructure)