### PR TITLE
chore: add allow_zero_version for 0.x.x versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.13"
 keywords = []
-version = "1.0.0"
+version = "0.1.0"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -146,6 +146,7 @@ branch = "main"
 build_command = "uv build"
 commit_message = "chore(release): {version}"
 tag_format = "{version}"
+allow_zero_version = true
 major_on_zero = false
 
 [tool.semantic_release.changelog]


### PR DESCRIPTION
### For reviewers

- [x] I used AI and thoroughly reviewed every code/docs change

### Description of the change

Fix semantic-release to properly support 0.x.x versioning.

**Root cause:** In python-semantic-release v10, `allow_zero_version` defaults to `false`, which forces the first version to be `1.0.0` regardless of other settings.

**Solution:** Add `allow_zero_version = true` to the semantic-release config.

**Configuration now:**
```toml
[tool.semantic_release]
allow_zero_version = true   # Enable 0.x.x versions (v10 default is false)
major_on_zero = false       # Breaking changes stay in 0.x
```

**Versioning behavior:**
- `feat:` commits → 0.2.0, 0.3.0, etc. (minor bumps)
- `fix:`/`perf:` commits → 0.1.1, 0.1.2, etc. (patch bumps)
- Breaking changes stay in 0.x until we explicitly release 1.0.0

### Relevant resources

- [python-semantic-release docs on allow_zero_version](https://python-semantic-release.readthedocs.io/en/latest/configuration/configuration.html#allow-zero-version)
- Part of #20 (PyPI publication prep)
- Related to #44 (PyPI publishing infrastructure)