### PR TITLE
feat: enable PyPI publishing infrastructure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,14 @@ name: release
 
 permissions:
   contents: write
+  id-token: write  # Required for PyPI trusted publishing
 
 jobs:
   release:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     concurrency: release
+    environment:
+      name: pypi  # Must match PyPI trusted publisher config
 
     steps:
     - name: Checkout
@@ -31,16 +34,28 @@ jobs:
       run: uv sync --group maintain
 
     - name: Semantic Release
+      id: release
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: uv run semantic-release version --changelog --push --tag --vcs-release
+      run: |
+        output=$(uv run semantic-release version --changelog --push --tag --vcs-release 2>&1) || true
+        echo "$output"
+        if echo "$output" | grep -q "No release will be made"; then
+          echo "released=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "released=true" >> "$GITHUB_OUTPUT"
+        fi
 
-    # Uncomment to publish to PyPI:
-    # - name: Publish to PyPI
-    #   if: secrets.PYPI_TOKEN != ''
-    #   env:
-    #     PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-    #   run: |
-    #     if [ -n "$PYPI_TOKEN" ]; then
-    #       uv publish --token $PYPI_TOKEN
-    #     fi
+    - name: Build package
+      if: steps.release.outputs.released == 'true'
+      run: uv build
+
+    # Uses PyPI trusted publishing - no token needed
+    # Setup: https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+    - name: Publish to TestPyPI
+      if: steps.release.outputs.released == 'true' && vars.PYPI_PUBLISH == 'test'
+      run: uv publish --publish-url https://test.pypi.org/legacy/
+
+    - name: Publish to PyPI
+      if: steps.release.outputs.released == 'true' && vars.PYPI_PUBLISH == 'true'
+      run: uv publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "ISC"
 license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.13"
-keywords = []
+keywords = ["mcp", "model-context-protocol", "unblu", "api", "llm", "ai", "chatbot", "customer-service"]
 version = "0.1.0"
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
### For reviewers

- [x] I used AI and thoroughly reviewed every code/docs change

### Description of the change

Enable PyPI publishing infrastructure using uv's recommended **trusted publishing** approach (no API tokens needed).

**Changes:**
- Add `id-token: write` permission for OIDC authentication
- Add `environment: pypi` for trusted publisher verification
- Build package only when semantic-release creates a new version
- Support both TestPyPI (`PYPI_PUBLISH=test`) and PyPI (`PYPI_PUBLISH=true`)
- Add keywords to pyproject.toml for PyPI discoverability

**Setup completed:**
- [x] Added pending publisher on TestPyPI
- [x] Created `pypi` environment in GitHub repo
- [x] Set `PYPI_PUBLISH=test` repository variable

**After testing, switch to production PyPI:**
- Add same trusted publisher config on https://pypi.org/manage/account/publishing/
- Change `PYPI_PUBLISH` variable to `true`

**Reference:** [uv docs on PyPI trusted publishing](https://docs.astral.sh/uv/guides/integration/github/#publishing-to-pypi)

### Relevant resources

- Closes #44
- Part of #20 (PyPI publication prep)