### PR TITLE
fix: improve semantic-release error handling in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,16 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        output=$(uv run semantic-release version --changelog --push --tag --vcs-release 2>&1) || true
+        set +e
+        output=$(uv run semantic-release version --changelog --push --tag --vcs-release 2>&1)
+        exit_code=$?
+        set -e
         echo "$output"
         if echo "$output" | grep -q "No release will be made"; then
           echo "released=false" >> "$GITHUB_OUTPUT"
+        elif [ $exit_code -ne 0 ]; then
+          echo "Semantic release failed with exit code $exit_code"
+          exit $exit_code
         else
           echo "released=true" >> "$GITHUB_OUTPUT"
         fi


### PR DESCRIPTION
### For reviewers

- [x] I used AI and thoroughly reviewed every code/docs change

### Description of the change

Fix a bug in the release workflow where semantic-release failures could be silently ignored.

**Problem:** The previous code used `|| true` to swallow all exit codes, then only checked if output contained "No release will be made". Any real failure (config error, push/tag failure) without that phrase would be treated as a successful release, causing build/publish to run for a release that never occurred.

**Solution:** Capture the exit code separately and:
1. If output contains "No release will be made" → `released=false` (expected, no error)
2. If exit code is non-zero → fail the workflow (real error)
3. If exit code is 0 → `released=true` (success)

### Relevant resources

- Part of #44 (PyPI publishing infrastructure)
- Part of #20 (PyPI publication prep)