### PR TITLE
chore: enable GitHub Pages deployment for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,13 +44,13 @@ jobs:
         with:
           path: site
 
-#   deploy:
-#     environment:
-#       name: github-pages
-#       url: ${{ steps.deployment.outputs.page_url }}
-#     runs-on: blacksmith-4vcpu-ubuntu-2404
-#     needs: build
-#     steps:
-#       - name: Deploy to GitHub Pages
-#         id: deployment
-#         uses: actions/deploy-pages@v4
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### For reviewers

- [x] I used AI and thoroughly reviewed every code/docs change

### Description of the change

Enable GitHub Pages deployment for the mkdocs documentation.

The docs workflow was already building the docs and uploading artifacts, but the deploy step was commented out. This PR uncomments it to actually deploy to GitHub Pages.

### Result

Docs will be available at: https://detailobsessed.github.io/unblu-mcp/