### PR TITLE
feat: add FastMCP error handling with ToolError and ErrorHandlingMiddleware

### DIFF
--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -10,6 +10,7 @@ import httpx
 import pytest
 import respx
 from fastmcp.client import Client
+from fastmcp.exceptions import ToolError
 
 from unblu_mcp._internal.server import create_server
 
@@ -184,13 +185,9 @@ class TestMetaTools:
 
     @pytest.mark.asyncio
     async def test_list_operations_not_found(self, mock_mcp_client: Client[FastMCPTransport]):
-        """Test list_operations with non-existent service."""
-        result = await mock_mcp_client.call_tool("list_operations", {"service": "NonExistent"})
-
-        assert result.structured_content is not None
-        assert isinstance(result.structured_content["result"], list)
-        assert len(result.structured_content["result"]) == 1
-        assert result.structured_content["result"][0]["error"] == "Service 'NonExistent' not found. Try: ['Test']..."
+        """Test list_operations with non-existent service raises ToolError."""
+        with pytest.raises(ToolError, match=r"Service 'NonExistent' not found"):
+            await mock_mcp_client.call_tool("list_operations", {"service": "NonExistent"})
 
     @pytest.mark.asyncio
     async def test_search_operations_mock(self, mock_mcp_client: Client[FastMCPTransport]):
@@ -237,14 +234,9 @@ class TestMetaTools:
 
     @pytest.mark.asyncio
     async def test_get_operation_schema_not_found(self, mock_mcp_client: Client[FastMCPTransport]):
-        """Test get_operation_schema with non-existent operation."""
-        result = await mock_mcp_client.call_tool("get_operation_schema", {"operation_id": "nonexistent"})
-
-        assert result.data is not None
-        assert result.structured_content is not None
-        assert isinstance(result.structured_content, dict)
-        assert result.structured_content["error"] == "Operation 'nonexistent' not found"
-        assert "not found" in result.structured_content["error"]
+        """Test get_operation_schema with non-existent operation raises ToolError."""
+        with pytest.raises(ToolError, match=r"Operation 'nonexistent' not found"):
+            await mock_mcp_client.call_tool("get_operation_schema", {"operation_id": "nonexistent"})
 
 
 @pytest.mark.asyncio
@@ -350,13 +342,9 @@ class TestEdgeCases:
 
     @pytest.mark.asyncio
     async def test_invalid_operation_id_schema(self, mock_mcp_client: Client[FastMCPTransport]):
-        """Test schema request with invalid operation ID format."""
-        result = await mock_mcp_client.call_tool("get_operation_schema", {"operation_id": "invalid$id"})
-
-        assert result.data is not None
-        assert result.structured_content is not None
-        assert isinstance(result.structured_content, dict)
-        assert result.structured_content["error"] == "Operation 'invalid$id' not found"
+        """Test schema request with invalid operation ID format raises ToolError."""
+        with pytest.raises(ToolError, match=r"Operation 'invalid\$id' not found"):
+            await mock_mcp_client.call_tool("get_operation_schema", {"operation_id": "invalid$id"})
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## For reviewers

- [x] AI was used for this PR

## Description

Improves error handling by leveraging FastMCP's built-in error handling patterns instead of returning error dicts.

## Root cause / Problem

Previously, tools returned error dictionaries like `{"error": "..."}` which:
- Don't integrate with FastMCP's error handling middleware
- Can be masked by `mask_error_details` setting
- Don't provide consistent error formatting

## Solution

1. **Use `ToolError`** for all client-facing errors - these are always propagated to clients regardless of settings
2. **Add `ErrorHandlingMiddleware`** for consistent error logging, tracking, and proper MCP error formatting
3. **Helpful error messages** - include suggestions like "Use search_operations() to find valid operation IDs"

### Tools updated:
- `list_operations()` - raises `ToolError` for unknown service
- `get_operation_schema()` - raises `ToolError` for unknown operation  
- `call_api()` - raises `ToolError` for unknown operation, missing path params, HTTP request errors

## Testing

- Added 5 new tests in `TestToolErrorHandling` class
- Updated 3 existing tests to expect `ToolError` instead of error dicts
- Fixed test isolation issue in logging tests
- 156 tests passing