### PR TITLE
docs: add timing metrics note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Logs include:
 - Log level
 - Tool name and arguments
 - Response summaries
+- **Request duration** (`duration_ms`) for performance analysis
 
 Logs are retained for 30 days and automatically rotated at midnight UTC.
 


### PR DESCRIPTION
## For reviewers

- [x] AI was used for this PR

## Description

Adds a note about request duration timing metrics (`duration_ms`) in the Logging section of the README.

This metric is already captured by FastMCP's LoggingMiddleware and helps with performance analysis.