### PR TITLE
ci: skip CI on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,17 @@ name: ci
     branches:
     - main
     - test-me-*
+    paths-ignore:
+    - "*.md"
+    - "docs/**"
+    - ".github/workflows/docs.yml"
   pull_request:
     branches:
     - main
+    paths-ignore:
+    - "*.md"
+    - "docs/**"
+    - ".github/workflows/docs.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## For reviewers

- [x] AI was used for this PR

## Description

Adds `paths-ignore` filters to the CI workflow to skip running the full test matrix on docs-only changes.

## Problem

Docs-only PRs (like #69) were triggering 14 CI jobs across 3 OS × 2 Python versions, wasting CI minutes on changes that don't affect code.

## Solution

Skip CI when only these files change:
- `*.md` - Markdown files in root
- `docs/**` - Documentation directory
- `.github/workflows/docs.yml` - Docs workflow itself

The docs workflow will still run to verify docs build correctly.