### PR TITLE
ci: chain workflows to ensure CI passes before release and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,17 +5,9 @@ name: ci
     branches:
     - main
     - test-me-*
-    paths-ignore:
-    - "*.md"
-    - "docs/**"
-    - ".github/workflows/docs.yml"
   pull_request:
     branches:
     - main
-    paths-ignore:
-    - "*.md"
-    - "docs/**"
-    - ".github/workflows/docs.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,9 @@
 name: docs
 
 "on":
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: [release]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -17,6 +17,8 @@ concurrency:
 
 jobs:
   build:
+    # Only run if release workflow succeeded (or manual trigger)
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: release
 
 "on":
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -12,6 +13,8 @@ permissions:
 
 jobs:
   release:
+    # Only run if CI succeeded (workflow_run triggers on completion regardless of result)
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     concurrency: release
     environment:

--- a/src/unblu_mcp/_internal/providers_k8s.py
+++ b/src/unblu_mcp/_internal/providers_k8s.py
@@ -161,9 +161,7 @@ class K8sConnectionProvider(ConnectionProvider):
                 await self._start_port_forward()
             else:
                 # Port already in use (orphaned from previous run?), reuse it
-                _logger.debug(
-                    "Port %d already in use, reusing", self._env_config.local_port
-                )
+                _logger.debug("Port %d already in use, reusing", self._env_config.local_port)
         else:
             # Another instance owns the port-forward, just wait for port
             self._owns_port_forward = False
@@ -273,9 +271,7 @@ class K8sConnectionProvider(ConnectionProvider):
             # Release the lock
             self._release_lock()
         else:
-            _logger.debug(
-                "Not owner, skipping port-forward cleanup for %s", self._env_config.name
-            )
+            _logger.debug("Not owner, skipping port-forward cleanup for %s", self._env_config.name)
 
     def get_config(self) -> ConnectionConfig:
         """Return connection config with trusted headers."""


### PR DESCRIPTION
### For reviewers

- [x] I used AI and thoroughly reviewed every code/docs change

### Description of the change

Previously, all three workflows (`ci`, `release`, `docs`) triggered independently on push to main, running in parallel. This meant a failed CI could still result in a PyPI release and docs deployment.

**Changes:**
- **CI workflow**: Removed `paths-ignore` so it always runs on main push (required for `workflow_run` chaining)
- **Release workflow**: Now triggers via `workflow_run` after CI completes, with a condition to only proceed if CI succeeded
- **Docs workflow**: Now triggers via `workflow_run` after Release completes, with a condition to only proceed if Release succeeded

**New flow:**
```
PR merged → CI → Release (if CI passes) → Docs (if Release passes)
```

Also configured branch protection on `main`:
- Require status checks: `quality (ubuntu, 3.13)`, `tests (ubuntu, 3.13, highest)`
- Linear history required
- Graphite-compatible settings

### Relevant resources

- [GitHub Docs: workflow_run trigger](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run)
- [Graphite: GitHub configuration guidelines](https://graphite.com/docs/github-configuration-guidelines)
