### PR TITLE
ci: use reusable semantic-release workflow from ci-components

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,63 +9,12 @@ name: release
 
 permissions:
   contents: write
-  id-token: write  # Required for PyPI trusted publishing
+  id-token: write
 
 jobs:
   release:
-    # Only run if CI succeeded (workflow_run triggers on completion regardless of result)
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    concurrency: release
-    environment:
-      name: pypi  # Must match PyPI trusted publisher config
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-        fetch-tags: true
-        lfs: true
-
-    - name: Setup uv and Python
-      uses: astral-sh/setup-uv@v7.1.5
-      with:
-        python-version: "3.13"
-        enable-cache: true
-
-    - name: Install dependencies
-      run: uv sync --group maintain
-
-    - name: Semantic Release
-      id: release
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        set +e
-        output=$(uv run semantic-release version --changelog --push --tag --vcs-release 2>&1)
-        exit_code=$?
-        set -e
-        echo "$output"
-        if echo "$output" | grep -q "No release will be made"; then
-          echo "released=false" >> "$GITHUB_OUTPUT"
-        elif [ $exit_code -ne 0 ]; then
-          echo "Semantic release failed with exit code $exit_code"
-          exit $exit_code
-        else
-          echo "released=true" >> "$GITHUB_OUTPUT"
-        fi
-
-    - name: Build package
-      if: steps.release.outputs.released == 'true'
-      run: uv build
-
-    # Uses PyPI trusted publishing - no token needed
-    # Setup: https://docs.pypi.org/trusted-publishers/adding-a-publisher/
-    - name: Publish to TestPyPI
-      if: steps.release.outputs.released == 'true' && vars.PYPI_PUBLISH == 'test'
-      run: uv publish --publish-url https://test.pypi.org/legacy/
-
-    - name: Publish to PyPI
-      if: steps.release.outputs.released == 'true' && vars.PYPI_PUBLISH == 'true'
-      run: uv publish
+    uses: detailobsessed/ci-components/.github/workflows/semantic-release-uv.yml@main
+    with:
+      pypi-publish: ${{ vars.PYPI_PUBLISH }}
+    secrets: inherit


### PR DESCRIPTION
Replaces the inline release workflow with a call to the reusable `semantic-release-uv.yml` workflow from ci-components.

**Changes:**
- 56 lines removed, 5 lines added
- Uses `secrets: inherit` for GITHUB_TOKEN
- Passes `vars.PYPI_PUBLISH` to control PyPI publishing mode

The reusable workflow handles:
- Python/UV setup with caching
- Semantic release with changelog generation
- Conditional PyPI/TestPyPI publishing