### PR TITLE
fix(k8s): add timeouts to kubectl subprocess calls to prevent server hang

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,15 @@
+name: Auto Merge Dependabot
+
+"on":
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    uses: detailobsessed/ci-components/.github/workflows/auto-merge-dependabot.yml@main
+    with:
+      merge-method: squash
+      update-types: minor,patch

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ config/k8s_environments.yaml
 .mypy_cache/
 .ruff_cache/
 __pycache__/
+
+# mcp-publisher tokens
+.mcpregistry_*

--- a/scripts/get_version.py
+++ b/scripts/get_version.py
@@ -22,7 +22,7 @@ def get_version() -> str:
     if scm_version.version <= Version("0.1"):  # Missing Git tags?
         with suppress(OSError, StopIteration):  # noqa: SIM117
             with _changelog.open("r", encoding="utf8") as file:
-                match = next(filter(None, map(_changelog_version_re.match, file)))
+                match = next(m for line in file if (m := _changelog_version_re.match(line)))
                 scm_version = scm_version._replace(version=Version(match.group(1)))
     return default_version_formatter(scm_version)
 


### PR DESCRIPTION
## Summary

Fixes server hang when kubectl authentication is unavailable (e.g., expired OIDC token).

## Problem

When using the K8s provider without valid kubectl auth, the MCP server would hang indefinitely. This was particularly problematic in Windsurf where the server would lock up completely, requiring a restart.

The root cause was `subprocess.run` calls without timeouts - if kubectl needed to prompt for OIDC login or was waiting for a response, it would block forever.

## Solution

Added 5-second timeouts to all kubectl subprocess calls:

- `kubectl auth can-i` check in `_start_port_forward()`
- `kubectl config current-context` in `detect_environment_from_context()`

Now the server fails gracefully with a clear error message guiding users to authenticate.

## Changes

- `src/unblu_mcp/_internal/providers_k8s.py`: Add timeouts and handle `subprocess.TimeoutExpired`
- `scripts/get_version.py`: Fix pre-existing type error (unrelated)
- `.github/workflows/auto-merge-dependabot.yml`: Add auto-merge for Dependabot PRs

## Testing

- All 198 tests pass
- Manually verified timeout behavior