### PR TITLE
feat: add MCP Registry publishing support

### DIFF
--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -1,0 +1,16 @@
+name: MCP Registry Publish
+
+on:
+  workflow_run:
+    workflows: [release]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    uses: detailobsessed/ci-components/.github/workflows/mcp-registry-publish-bun.yml@main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ watch = "gh run watch"
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
+version_variables = ["server.json:version"]
 branch = "main"
 build_command = "uv build"
 commit_message = "chore(release): {version}"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.detailobsessed/unblu",
+  "description": "Unblu MCP Server - Token-efficient access to 300+ Unblu API endpoints",
+  "repository": {
+    "url": "https://github.com/detailobsessed/unblu-mcp",
+    "source": "github"
+  },
+  "version": "0.3.4",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "unblu-mcp",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "UNBLU_BASE_URL",
+          "description": "Unblu API base URL (e.g., https://your-instance.unblu.cloud/app/rest/v4)",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "UNBLU_API_KEY",
+          "description": "Unblu API key for authentication",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "UNBLU_USERNAME",
+          "description": "Unblu username for basic auth (alternative to API key)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "UNBLU_PASSWORD",
+          "description": "Unblu password for basic auth (alternative to API key)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Enables automatic publishing to the official MCP Registry after PyPI releases.

## Problem

The unblu-mcp server is published to PyPI but not discoverable in the official MCP Registry at registry.modelcontextprotocol.io.

## Solution

Added MCP Registry publishing infrastructure following the same pattern as efficient-gitlab-mcp.

## Changes

- `server.json`: MCP server metadata for registry (name, description, PyPI package, env vars)
- `.github/workflows/mcp-registry-publish.yml`: Workflow triggered after release
- `pyproject.toml`: Added `version_variables` to sync server.json version during release
- `.gitignore`: Added `.mcpregistry_*` for local publisher tokens

## Release Flow

```
CI → Release (PyPI publish + version sync) → MCP Registry Publish
```

## Prerequisites (one-time, already done)

- [x] Org membership is public at https://github.com/orgs/detailobsessed/people
- [x] First publish with `mcp-publisher login github && mcp-publisher publish`

## Testing

- All 198 tests pass
- Workflow syntax validated by actionlint