### PR TITLE
fix: move PyPI publish to separate job for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,5 +16,28 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     uses: detailobsessed/ci-components/.github/workflows/semantic-release-uv.yml@main
     with:
-      pypi-publish: ${{ vars.PYPI_PUBLISH }}
+      pypi-publish: "false"
     secrets: inherit
+
+  pypi-publish:
+    needs: release
+    if: needs.release.outputs.released == 'true' && vars.PYPI_PUBLISH == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/unblu-mcp
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        run: uv publish

--- a/uv.lock
+++ b/uv.lock
@@ -2676,7 +2676,7 @@ wheels = [
 
 [[package]]
 name = "unblu-mcp"
-version = "0.3.4"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
Move PyPI publish step from the reusable workflow to a separate job in the calling workflow to enable trusted publishing.

## Problem
PyPI trusted publishing cannot work from within reusable workflows. The OIDC token's `job_workflow_ref` claim points to the reusable workflow's repository, but PyPI validates against the calling repository. This caused all PyPI publish attempts to fail with "no corresponding publisher" errors.

## Solution
- Disable `pypi-publish` in the reusable workflow call
- Add a new `pypi-publish` job that runs after the release job
- The new job uses the `released` output from the reusable workflow to conditionally publish
- Configure the job with the `pypi` environment for trusted publishing

## Changes
- `.github/workflows/release.yml`: Added `pypi-publish` job with proper environment and permissions

## Related
- ci-components PR #11: Exposes `released` output from semantic-release-uv workflow
- PyPI docs: [Trusted publishing cannot be used from within a reusable workflow](https://github.com/pypa/gh-action-pypi-publish#trusted-publishing)

### For reviewers
- [x] I used AI and thoroughly reviewed every code/docs change