### PR TITLE
docs: add MCP Registry name to README for ownership validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # unblu-mcp
 
+<!-- mcp-name: io.github.detailobsessed/unblu -->
+
 [![ci](https://github.com/detailobsessed/unblu-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/detailobsessed/unblu-mcp/actions/workflows/ci.yml)
 [![documentation](https://img.shields.io/badge/docs-mkdocs-708FCC.svg?style=flat)](https://detailobsessed.github.io/unblu-mcp/)
 [![pypi version](https://img.shields.io/pypi/v/unblu-mcp.svg)](https://pypi.org/project/unblu-mcp/)

--- a/server.json
+++ b/server.json
@@ -11,6 +11,7 @@
     {
       "registryType": "pypi",
       "identifier": "unblu-mcp",
+      "version": "0.4.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Just adds a single line to README.md, required by official modelcontextprotocol.io registry.