### PR TITLE
fix: simplify port-forward coordination and add auto-restart

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "httpx>=0.27.0",
     "pydantic>=2.0.0",
     "prek",
-    "filelock>=3.20.1",
 ]
 
 [project.urls]

--- a/src/unblu_mcp/_internal/providers.py
+++ b/src/unblu_mcp/_internal/providers.py
@@ -74,6 +74,15 @@ class ConnectionProvider(ABC):
         Should be safe to call even if setup() was never called.
         """
 
+    async def ensure_connection(self) -> None:  # noqa: B027
+        """Ensure the connection is alive, restarting if needed.
+
+        Called before each API request. Override this in providers that need
+        to handle connection recovery (e.g., restarting a dead port-forward).
+
+        Default implementation does nothing.
+        """
+
     @abstractmethod
     def get_config(self) -> ConnectionConfig:
         """Return the current connection configuration.

--- a/src/unblu_mcp/_internal/server.py
+++ b/src/unblu_mcp/_internal/server.py
@@ -581,6 +581,9 @@ Example workflow:
         method = op["method"].lower()
         request_headers = dict(headers or {})
 
+        # Ensure connection is alive (handles port-forward restarts for K8s provider)
+        await provider.ensure_connection()
+
         try:
             response = await client.request(
                 method=method,

--- a/uv.lock
+++ b/uv.lock
@@ -748,15 +748,6 @@ wheels = [
 ]
 
 [[package]]
-name = "filelock"
-version = "3.20.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a7/23/ce7a1126827cedeb958fc043d61745754464eb56c5937c35bbf2b8e26f34/filelock-3.20.1.tar.gz", hash = "sha256:b8360948b351b80f420878d8516519a2204b07aefcdcfd24912a5d33127f188c", size = 19476, upload-time = "2025-12-15T23:54:28.027Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/7f/a1a97644e39e7316d850784c642093c99df1290a460df4ede27659056834/filelock-3.20.1-py3-none-any.whl", hash = "sha256:15d9e9a67306188a44baa72f569d2bfd803076269365fdea0934385da4dc361a", size = 16666, upload-time = "2025-12-15T23:54:26.874Z" },
-]
-
-[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2676,11 +2667,10 @@ wheels = [
 
 [[package]]
 name = "unblu-mcp"
-version = "0.4.3"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
-    { name = "filelock" },
     { name = "httpx" },
     { name = "prek" },
     { name = "pydantic" },
@@ -2734,7 +2724,6 @@ maintain = [
 requires-dist = [
     { name = "eunomia-mcp", marker = "extra == 'safety'", specifier = ">=0.3.10" },
     { name = "fastmcp", specifier = ">=2.14.1" },
-    { name = "filelock", specifier = ">=3.20.1" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "prek" },
     { name = "pydantic", specifier = ">=2.0.0" },


### PR DESCRIPTION
Fixes the K8s port-forward timeout issue caused by zombie processes holding file locks.

## Problem
When multiple MCP server instances ran (e.g., multiple Windsurf windows), crashed instances would hold file locks indefinitely, blocking new instances from starting port-forwards.

## Solution
- **Remove file-lock coordination** — Use simple port-check approach instead
- **Add `ensure_connection()`** — Auto-restarts dead/malfunctioning port-forwards before API calls
- **Kill malfunctioning processes** — If process is alive but port not available, kill and restart
- **Remove `filelock` dependency**

## Behavior
- If port is in use → reuse existing connection
- If port is free → start new port-forward
- If our port-forward dies → automatically restart on next API call